### PR TITLE
Fix "catalog" bug (normalizing repo names where it shouldn't)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
       - run: sudo ctr run --rm totally-fake-never-exists:true-yoloci true-yoloci
 
       # test listing
-      - run: docker run --rm --network=container:containerd-registry gcr.io/go-containerregistry/crane catalog localhost:5000 | grep totally-fake-never-exists # TODO anchor this regex after fixing the bug that's normalizing the "catalog" response to "docker.io/library/totally-fake-never-exists"
-      - run: docker run --rm --network=container:containerd-registry gcr.io/go-containerregistry/crane ls localhost:5000/totally-fake-never-exists | grep true-yoloci
+      - run: docker run --rm --network=container:containerd-registry gcr.io/go-containerregistry/crane catalog localhost:5000 | grep -E '^totally-fake-never-exists$'
+      - run: docker run --rm --network=container:containerd-registry gcr.io/go-containerregistry/crane ls localhost:5000/totally-fake-never-exists | grep -E '^true-yoloci$'


### PR DESCRIPTION
In #2, I added a test that hit the catalog endpoint after copying an image to the "top level" inside the containerd image store, and it became `docker.io/library/xxx` which isn't right!  (trying to query it from that path later would've failed)